### PR TITLE
Add dynamo db

### DIFF
--- a/dynamoDB-test-result-uploader.js
+++ b/dynamoDB-test-result-uploader.js
@@ -1,20 +1,16 @@
 const { PutItemCommand, DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { marshall } = require('@aws-sdk/util-dynamodb');
+const fs = require('fs');
 
 // TODO: 2 options for ddbClient - either use the existing one in CLI or create a new one. 
 // Currently, it is hard coded to a new one for testing purposes.
 // const { ddbClient } = require('./ddbClient'); get it from conifer config?
 
 // TODO: Either use ddbClient or set the AWS Region using the config file.
-const REGION = 'ap-northeast-1'; 
+const REGION = 'ap-northeast-1';  
 // TODO: Create an Amazon DynamoDB service client object.
 const ddbClient = new DynamoDBClient({ region: REGION });
 
-const fs = require('fs');
-const path = require('path');
-const Observer = require('./test-folder-watcher');
-const observer = new Observer();
-const folder = `./cypress/newResults`;
 
 // TODO: figure out here putItem needs to be called and remove hard-coded values
 const updateExisitingTestFileInDynamo  = async (reportFilePath) => {
@@ -51,16 +47,3 @@ const updateExisitingTestFileInDynamo  = async (reportFilePath) => {
 };
 
 module.exports = updateExisitingTestFileInDynamo;
-
-// observer.on('file-added', (log) => {
-//   // print error message to console
-//   console.log(`File was added: ${log.filePath}`);
-
-//   // TODO: Need to test and ensure this file path matches file globbing which is the base used to create primary keys
-//   const fullFilePath = `./${log.filePath}`;
-
-//   // Update the corresponsing test file in dynamoDB
-//   updateExisitingTestFileInDynamo(fullFilePath);
-// });
-
-// observer.watchFolder(folder);

--- a/dynamoDB-test-result-uploader.js
+++ b/dynamoDB-test-result-uploader.js
@@ -1,0 +1,65 @@
+const { PutItemCommand, DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { marshall } = require('@aws-sdk/util-dynamodb');
+
+
+// TODO: 2 options for ddbClient - either use the existing one in CLI or create a new one. 
+// Currently, it is hard coded to a new one for testing purposes.
+// const { ddbClient } = require('./ddbClient'); get it from conifer config?
+
+// TODO: Either use ddbClient or set the AWS Region using the config file.
+const REGION = 'ap-northeast-1'; 
+// TODO: Create an Amazon DynamoDB service client object.
+const ddbClient = new DynamoDBClient({ region: REGION });
+
+const fs = require('fs');
+const path = require('path');
+const Observer = require('./test-folder-watcher');
+const observer = new Observer();
+const folder = `./cypress/newResults`;
+
+// TODO: figure out here putItem needs to be called and remove hard-coded values
+const updateExisitingTestFileInDynamo  = async (reportFilePath) => {
+  try {
+    // rawData is the mochawesome generated json report file that is being watched by file watcher
+    const rawData = fs.readFileSync(reportFilePath, 'utf-8'); 
+    const json = JSON.parse(rawData);
+
+    // TODO: Sync how to get the Test Run ID logic with the rest of the flow.
+    //  const testRunID = fs.readFileSync('/Users/ainaasakinah/Code/capstone_research/conifer/test-run-id.txt', 'utf-8');
+    const testRunID = '6ff736cd-80da-4694-a1f2-7ec50dcd1933'; 
+    const testFileName = json.results[0].fullFile;
+    const passPercent = json.results[0].passPercent;
+
+    // The json must include the primary key, testFileName and sort key, testRunID to successfully upload
+    // We grab the full spec name from the json file because we need the .cy or .spec file name to update existing file in dynamoDB
+    // - .cy and .spec is not included in the mochawesome file name
+    json.testFileName = `./${testFileName}`; 
+    json.testRunID = testRunID;
+    json.status = passPercent === 100 ? 'pass' : 'fail';
+
+    const params = {
+      TableName: 'Conifer_Test_Runs',
+      Key: { testFileName: testFileName, testRunID: testRunID },
+      Item: marshall(json)
+    };
+
+    const data = await ddbClient.send(new PutItemCommand(params));
+    console.log('Item Updated', data);
+    return data;
+  } catch (err) {
+    console.log('Error', err);
+  }
+};
+
+observer.on('file-added', (log) => {
+  // print error message to console
+  console.log(`File was added: ${log.filePath}`);
+
+  // TODO: Need to test and ensure this file path matches file globbing which is the base used to create primary keys
+  const fullFilePath = `./${log.filePath}`;
+
+  // Update the corresponsing test file in dynamoDB
+  updateExisitingTestFileInDynamo(fullFilePath);
+});
+
+observer.watchFolder(folder);

--- a/dynamoDB-test-result-uploader.js
+++ b/dynamoDB-test-result-uploader.js
@@ -1,7 +1,6 @@
 const { PutItemCommand, DynamoDBClient } = require('@aws-sdk/client-dynamodb');
 const { marshall } = require('@aws-sdk/util-dynamodb');
 
-
 // TODO: 2 options for ddbClient - either use the existing one in CLI or create a new one. 
 // Currently, it is hard coded to a new one for testing purposes.
 // const { ddbClient } = require('./ddbClient'); get it from conifer config?
@@ -25,7 +24,7 @@ const updateExisitingTestFileInDynamo  = async (reportFilePath) => {
     const json = JSON.parse(rawData);
 
     // TODO: Sync how to get the Test Run ID logic with the rest of the flow.
-    //  const testRunID = fs.readFileSync('/Users/ainaasakinah/Code/capstone_research/conifer/test-run-id.txt', 'utf-8');
+    // const testRunID = fs.readFileSync('/Users/ainaasakinah/Code/capstone_research/conifer/test-run-id.txt', 'utf-8');
     const testRunID = '6ff736cd-80da-4694-a1f2-7ec50dcd1933'; 
     const testFileName = json.results[0].fullFile;
     const passPercent = json.results[0].passPercent;
@@ -51,15 +50,17 @@ const updateExisitingTestFileInDynamo  = async (reportFilePath) => {
   }
 };
 
-observer.on('file-added', (log) => {
-  // print error message to console
-  console.log(`File was added: ${log.filePath}`);
+module.exports = updateExisitingTestFileInDynamo;
 
-  // TODO: Need to test and ensure this file path matches file globbing which is the base used to create primary keys
-  const fullFilePath = `./${log.filePath}`;
+// observer.on('file-added', (log) => {
+//   // print error message to console
+//   console.log(`File was added: ${log.filePath}`);
 
-  // Update the corresponsing test file in dynamoDB
-  updateExisitingTestFileInDynamo(fullFilePath);
-});
+//   // TODO: Need to test and ensure this file path matches file globbing which is the base used to create primary keys
+//   const fullFilePath = `./${log.filePath}`;
 
-observer.watchFolder(folder);
+//   // Update the corresponsing test file in dynamoDB
+//   updateExisitingTestFileInDynamo(fullFilePath);
+// });
+
+// observer.watchFolder(folder);

--- a/observer.js
+++ b/observer.js
@@ -1,0 +1,22 @@
+const Observer = require('./test-folder-watcher');
+const observer = new Observer();
+const config = JSON.parse(fs.readFileSync(CONIFER_CONFIG_FILE));
+const folder = `${config.testDirectory}/results`;
+
+observer.on('file-added', (log) => {
+  // print error message to console
+  console.log(`File was added: ${log.filePath}`);
+
+  const uuid = path.parse(log.filePath).name;
+
+  // Export file to s3 bucket
+  putInBucket(log.filePath, uuid);
+
+  // TODO: Need to test and ensure this file path matches file globbing which is the base used to create primary keys
+  const fullFilePath = `./${log.filePath}`;
+
+  // Update the corresponsing test file in dynamoDB
+  updateExisitingTestFileInDynamo(fullFilePath);
+});
+
+observer.watchFolder(folder);

--- a/observer.js
+++ b/observer.js
@@ -3,6 +3,9 @@ const observer = new Observer();
 const config = JSON.parse(fs.readFileSync(CONIFER_CONFIG_FILE));
 const folder = `${config.testDirectory}/results`;
 
+const putInBucket = require('./s3-test-result-uploader');
+const updateExisitingTestFileInDynamo = require('./dynamoDB-test-result-uploader');
+
 observer.on('file-added', (log) => {
   // print error message to console
   console.log(`File was added: ${log.filePath}`);

--- a/observer.js
+++ b/observer.js
@@ -15,7 +15,7 @@ observer.on('file-added', (log) => {
   const uuid = path.parse(log.filePath).name;
 
   // Export file to s3 bucket
-  putInBucket(log.filePath, uuid);
+  putInBucket(log.filePath, uuid, config.bucketName);
 
   // TODO: Need to test and ensure this file path matches file globbing which is the base used to create primary keys
   const fullFilePath = `./${log.filePath}`;

--- a/observer.js
+++ b/observer.js
@@ -6,6 +6,9 @@ const folder = `${config.testDirectory}/results`;
 const putInBucket = require('./s3-test-result-uploader');
 const updateExisitingTestFileInDynamo = require('./dynamoDB-test-result-uploader');
 
+console.log(putInBucket);
+console.log(updateExisitingTestFileInDynamo);
+
 observer.on('file-added', (log) => {
   // print error message to console
   console.log(`File was added: ${log.filePath}`);

--- a/observer.js
+++ b/observer.js
@@ -1,13 +1,12 @@
 const Observer = require('./test-folder-watcher');
 const observer = new Observer();
-const config = JSON.parse(fs.readFileSync(CONIFER_CONFIG_FILE));
-const folder = `${config.testDirectory}/results`;
+const config = JSON.parse(fs.readFileSync('/app/.conifer/conifer-config.json'));
+
+// const folder = `${config.testDirectory}/results`;
+const folder = `/app/cypress/results`;
 
 const putInBucket = require('./s3-test-result-uploader');
 const updateExisitingTestFileInDynamo = require('./dynamoDB-test-result-uploader');
-
-console.log(putInBucket);
-console.log(updateExisitingTestFileInDynamo);
 
 observer.on('file-added', (log) => {
   // print error message to console

--- a/s3-test-result-uploader.js
+++ b/s3-test-result-uploader.js
@@ -14,7 +14,7 @@ const putInBucket = async (
   bucketName = 'conifer-test-output-bucket'
 ) => {
   try {
-    const REGION = 'us-west-1';
+    const REGION = 'us-west-1'; // TODO: how to get users's region? conifer cdk output? 
     const s3Client = new S3Client({ region: REGION });
     const fileStream = fs.createReadStream(pathString);
 

--- a/s3-test-result-uploader.js
+++ b/s3-test-result-uploader.js
@@ -32,16 +32,18 @@ const putInBucket = async (
   }
 };
 
-observer.on('file-added', (log) => {
-  // print error message to console
-  console.log(`File was added: ${log.filePath}`);
+module.exports = putInBucket;
 
-  const uuid = path.parse(log.filePath).name;
+// observer.on('file-added', (log) => {
+//   // print error message to console
+//   console.log(`File was added: ${log.filePath}`);
 
-  // Export file to s3 bucket
-  putInBucket(log.filePath, uuid);
-});
+//   const uuid = path.parse(log.filePath).name;
 
-observer.watchFolder(folder);
+//   // Export file to s3 bucket
+//   putInBucket(log.filePath, uuid);
+// });
+
+// observer.watchFolder(folder);
 
 

--- a/s3-test-result-uploader.js
+++ b/s3-test-result-uploader.js
@@ -4,7 +4,7 @@ const { PutObjectCommand, S3Client } = require('@aws-sdk/client-s3');
 const putInBucket = async (
   pathString,
   uuid,
-  bucketName = 'conifer-test-output-bucket'
+  bucketName,
 ) => {
   try {
     const REGION = 'us-west-1'; // TODO: how to get users's region? conifer cdk output? 

--- a/s3-test-result-uploader.js
+++ b/s3-test-result-uploader.js
@@ -1,11 +1,4 @@
-const path = require('path');
 const fs = require('fs');
-
-const Observer = require('./test-folder-watcher');
-const observer = new Observer();
-const config = JSON.parse(fs.readFileSync(CONIFER_CONFIG_FILE));
-const folder = `${config.testDirectory}/results`;
-
 const { PutObjectCommand, S3Client } = require('@aws-sdk/client-s3');
 
 const putInBucket = async (
@@ -33,17 +26,4 @@ const putInBucket = async (
 };
 
 module.exports = putInBucket;
-
-// observer.on('file-added', (log) => {
-//   // print error message to console
-//   console.log(`File was added: ${log.filePath}`);
-
-//   const uuid = path.parse(log.filePath).name;
-
-//   // Export file to s3 bucket
-//   putInBucket(log.filePath, uuid);
-// });
-
-// observer.watchFolder(folder);
-
 


### PR DESCRIPTION
- Added a dynamoDB test result uploader
- Refactor observer into it's own module which called the S3 test result uploader and dynamoDB test result uploader
- Note that we must resolve a few hard-coded values depependencies, testRunID and dynamo DB client. 
- We also need to test and make sure that there are no issues when updating the test file name in dynamoDB - not a major issue, the file names are just inconsistent across the flow and it's just a matter of making sure that it is consistent. 